### PR TITLE
Add binary STL recognition and fix tests

### DIFF
--- a/freedesktop.org.xml.in
+++ b/freedesktop.org.xml.in
@@ -6933,7 +6933,13 @@ command to generate the output files.
   <mime-type type="model/vnd.stl-binary">
     <_comment>STL 3D model (binary)</_comment>
     <sub-class-of type="application/octet-stream"/>
-    <generic-icon name="binary"/>
+    <magic priority="10">
+      <match type="byte" value="0x0" mask="0xFFFF" offset="134">
+        <match type="byte" value="0x0" mask="0xFFFF" offset="184">
+          <match type="byte" value="0x0" mask="0xFFFF" offset="234"/>
+        </match>
+      </match>
+    </magic>
     <glob pattern="*.stl"/>
   </mime-type>
 
@@ -6948,7 +6954,7 @@ command to generate the output files.
     <glob pattern="*.stl"/>
   </mime-type>
 
-  <mime-type type="application/x-gcode">
+  <mime-type type="application/vnd.gcode">
     <_comment>G-code file</_comment>
     <sub-class-of type="text/plain"/>
     <generic-icon name="text-x-generic"/>

--- a/tests/list
+++ b/tests/list
@@ -628,7 +628,7 @@ dbus-comment.service text/x-dbus-service
 
 # 3D models and GCODEs
 binary.stl model/vnd.stl-binary
-ascii.stl model/vnd.stl-ascii
-binary.stl model/vnd.stl-ascii ox
-ascii.stl model/vnd.stl-binary ox
-test.gcode application/x-gcode
+ascii.stl model/vnd.stl-ascii x
+binary.stl model/vnd.stl-ascii xxx
+ascii.stl model/vnd.stl-binary oxx
+test.gcode application/vnd.gcode ox


### PR DESCRIPTION
Commit message:
```
Add a way to recognize STL binary files based on the empty 2 bytes at
the end of every facet description.
.
The prefix "x-" is deprecated according to RFC 6648.
(https://tools.ietf.org/html/rfc6648)
.
Rewrite the expected tests results. (Closes: #2)
```
A few comments on this:
- I found that the software [FreeCAD](http://www.freecadweb.org) uses the extension `.stl` for binary STL files and `.ast` for ASCII STL files. However the program [Slic3r](http://slic3r.org) only recognizes the first one.
- Slic3r detects up to 4 different file extensions for g-code files: `.gcode`, `.gco`, `.g` and `.ngc`. FreeCAD works with up to 7: `.nc`, `.gc`, `.ncc`, `.ngc`, `.cnc`, `.tap` and `.gcode`. I'm in doubt of whether we should include any of this in our g-code specification.
- I still would like to find a way to properly detect g-code files but I haven't come up with anything smart yet. It detects them as simple text files for now.